### PR TITLE
Archive this repo with pointer to the new sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,13 @@ description: "This sample implements a function triggered by Azure Blob Storage 
 
 # Azure Storage Blob Trigger Image Resize Function in Node.js using the v10 SDK
 
+> IMPORTANT! This sample uses the older version of the Storage Blob SDK i.e. azure-storage. Please refer to the sample [storage-blob-resize-function](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-blob/samples/storage-blob-resize-function) that uses the latest version of the Storage Blob SDK i.e. [@azure/storage-blob](https://www.npmjs.com/package/@azure/storage-blob) instead.
+
 This sample implements a function triggered by Azure Blob Storage to resize an image in Node.js. Once the image is resized, the thumbnail image is uploaded back to blob storage.
 
 The key aspects of this sample are in the function bindings and implementation.
 
 This sample is used by the topic [Tutorial: Automate resizing uploaded images using Event Grid](https://docs.microsoft.com/en-us/azure/event-grid/resize-images-on-storage-blob-upload-event?tabs=nodejsv10#deploy-the-function-code/)
-
-## Use latest Storage Blob SDK
-The Storage Blob SDK package version in this repo is 10.x. It's strongly recommended that you use the latest version of the Storage Blob SDK package, please refer to the sample [storage-blob-resize-function](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-blob/samples/storage-blob-resize-function).
 
 ## Function bindings
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ The key aspects of this sample are in the function bindings and implementation.
 
 This sample is used by the topic [Tutorial: Automate resizing uploaded images using Event Grid](https://docs.microsoft.com/en-us/azure/event-grid/resize-images-on-storage-blob-upload-event?tabs=nodejsv10#deploy-the-function-code/)
 
-
 ## Use latest Storage Blob SDK
 The Storage Blob SDK package version in this repo is 10.x. It's strongly recommended that you use the latest version of the Storage Blob SDK package, please refer to the sample [storage-blob-resize-function](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-blob/samples/storage-blob-resize-function).
+
 ## Function bindings
 
 In order to interface with image data, you need to configure the function to process binary data.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ description: "This sample implements a function triggered by Azure Blob Storage 
 
 # Azure Storage Blob Trigger Image Resize Function in Node.js using the v10 SDK
 
-> IMPORTANT! This sample uses the older version of the Storage Blob SDK i.e. azure-storage. Please refer to the sample [storage-blob-resize-function](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-blob/samples/storage-blob-resize-function) that uses the latest version of the Storage Blob SDK i.e. [@azure/storage-blob](https://www.npmjs.com/package/@azure/storage-blob) instead.
+> IMPORTANT! This sample uses the version 10 of the Storage Blob SDK. Please refer to the sample [storage-blob-resize-function](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-blob/samples/storage-blob-resize-function) that uses the latest version of the Storage Blob SDK instead.
 
 This sample implements a function triggered by Azure Blob Storage to resize an image in Node.js. Once the image is resized, the thumbnail image is uploaded back to blob storage.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ The key aspects of this sample are in the function bindings and implementation.
 
 This sample is used by the topic [Tutorial: Automate resizing uploaded images using Event Grid](https://docs.microsoft.com/en-us/azure/event-grid/resize-images-on-storage-blob-upload-event?tabs=nodejsv10#deploy-the-function-code/)
 
+## This sample already updated in [Storage SDK Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-blob/samples/storage-blob-resize-function).
+
 ## Function bindings
 
 In order to interface with image data, you need to configure the function to process binary data.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ The key aspects of this sample are in the function bindings and implementation.
 
 This sample is used by the topic [Tutorial: Automate resizing uploaded images using Event Grid](https://docs.microsoft.com/en-us/azure/event-grid/resize-images-on-storage-blob-upload-event?tabs=nodejsv10#deploy-the-function-code/)
 
-## This sample already updated in [Storage SDK Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-blob/samples/storage-blob-resize-function).
 
+## Use latest Storage Blob SDK
+The Storage Blob SDK package version in this repo is 10.x. It's strongly recommended that you use the latest version of the Storage Blob SDK package, please refer to the sample [storage-blob-resize-function](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-blob/samples/storage-blob-resize-function).
 ## Function bindings
 
 In order to interface with image data, you need to configure the function to process binary data.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ description: "This sample implements a function triggered by Azure Blob Storage 
 
 # Azure Storage Blob Trigger Image Resize Function in Node.js using the v10 SDK
 
-> IMPORTANT! This sample uses the version 10 of the Storage Blob SDK. Please refer to the sample [storage-blob-resize-function](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-blob/samples/storage-blob-resize-function) that uses the latest version of the Storage Blob SDK instead.
+> IMPORTANT! This sample uses the version 10 of the Storage Blob SDK. Please refer to the sample [storage-blob-resize-function](https://github.com/Azure-Samples/storage-blob-resize-function-node) that uses the latest version of the Storage Blob SDK instead.
 
 This sample implements a function triggered by Azure Blob Storage to resize an image in Node.js. Once the image is resized, the thumbnail image is uploaded back to blob storage.
 


### PR DESCRIPTION
According to the https://github.com/Azure-Samples/storage-blob-resize-function-node-v10/pull/1#issuecomment-788220155,  update README to archive this repo with pointer to the [new sample](https://github.com/azure/azure-sdk-for-js/tree/master/sdk/storage/storage-blob/samples).

@ramya-rao-a @jongio for notification.